### PR TITLE
[8.x] Fix: Remove unnecessary line in the `Illuminate\Validation\Validator`

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -280,7 +280,6 @@ class Validator implements ValidatorContract
     {
         $this->dotPlaceholder = Str::random();
 
-        $this->initialRules = $rules;
         $this->translator = $translator;
         $this->customMessages = $messages;
         $this->data = $this->parseData($data);


### PR DESCRIPTION
There's unnecessary line in the constructor, 'cause we set `initialRules` in the `setRules` method a little later. 
It could confuse some of the people who what to understand what happens under the hood of validation.